### PR TITLE
Add a new group monitoring, and add the public grafana dashboard to s…

### DIFF
--- a/docs/docs/monitoring/beacon-node.md
+++ b/docs/docs/monitoring/beacon-node.md
@@ -1,0 +1,10 @@
+---
+id: beacon-node
+title: Consensus Beacon Node
+sidebar_label: Monitoring Consensus Beacon Node
+description: Monitoring Default Metrics Consensus Beacon Node
+keywords: [tikuna, team, scientists]
+custom_edit_url: null
+---
+
+<iframe width="130%" height="500" src="https://dash.tikuna.io/public-dashboards/d7322b0297754a82bdff153e74c5d2c0?orgId=0" frameBorder="0" allowFullScreen loading="lazy"></iframe> 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -46,7 +46,6 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/edenia/tikuna.io/tree/master/",
         },
         blog: {
           showReadingTime: true,
@@ -85,6 +84,12 @@ const config = {
             position: "left",
             label: "About Tikuna",
           },
+          {
+            type: "doc",
+            docId: "monitoring/beacon-node",
+            position: "left",
+            label: "Monitoring",
+          },
           { to: "/blog", label: "Blog", position: "left" },
           {
             type: "localeDropdown",
@@ -117,6 +122,10 @@ const config = {
               {
                 label: "About Tikuna",
                 to: "/docs/about/team",
+              },
+              {
+                label: "Monitoring",
+                to: "docs/monitoring/beacon-node",
               },
             ],
           },

--- a/docs/i18n/es/code.json
+++ b/docs/i18n/es/code.json
@@ -223,7 +223,7 @@
     "description": "The label used in blog post item excerpts to link to full blog posts"
   },
   "theme.blog.post.readMoreLabel": {
-    "message": "Read more about {title}",
+    "message": "Leer más acerca de {title}",
     "description": "The ARIA label for the link to full blog posts from excerpts"
   },
   "theme.blog.post.readingTime.plurals": {

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -10,5 +10,9 @@
   "sidebar.tutorialSidebar.category.About": {
     "message": "Acerca de",
     "description": "The label for category About in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Monitoring": {
+    "message": "Monitoreo",
+    "description": "The label for category Monitoring in sidebar tutorialSidebar"
   }
 }

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/about/sakundi.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/about/sakundi.md
@@ -6,3 +6,6 @@ description: About Sakundi Blockchain Cybersecurity
 keywords: [ sakundi, blockchain, cyber-security ]
 ---
 
+<div className="sakundiLogo logo"></div>
+
+Sakundi es una organización de seguridad y privacidad de Blockchain basada en la investigación. Ofrece soluciones de monitoreo de seguridad para organizaciones Blockchain y aplicaciones distribuidas basadas en herramientas de Inteligencia Artificial.

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/about/team.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/about/team.md
@@ -5,3 +5,4 @@ sidebar_label: El equipo
 description: Meet the team of scientist and developers and engineers at Tikuna
 keywords: [ tikuna, team, scientists ]
 ---
+![edenia logo](/img/second-card.webp)

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/monitoring/beacon-node.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/monitoring/beacon-node.md
@@ -1,0 +1,10 @@
+---
+id: beacon-node
+title: Nodo De Consenso Beacon
+sidebar_label: Monitoreo Nodo De Consenso Beacon
+description: Monitoring Default Metrics Consensus Beacon Node
+keywords: [tikuna, team, scientists]
+custom_edit_url: null
+---
+
+<iframe width="130%" height="500" src="https://dash.tikuna.io/public-dashboards/d7322b0297754a82bdff153e74c5d2c0?orgId=0" frameBorder="0" allowFullScreen loading="lazy"></iframe> 

--- a/docs/i18n/es/docusaurus-plugin-content-pages/markdown-page.md
+++ b/docs/i18n/es/docusaurus-plugin-content-pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.

--- a/docs/i18n/es/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/es/docusaurus-theme-classic/footer.json
@@ -15,6 +15,10 @@
     "message": "Investigación",
     "description": "The label of footer link with label=Research linking to /docs/research/intro"
   },
+  "link.item.label.Monitoring": {
+    "message": "Monitoreo",
+    "description": "The label of footer link with label=Research linking to /docs/research/intro"
+  },
   "link.item.label.About Tikuna": {
     "message": "Acerca de Tikuna",
     "description": "The label of footer link with label=About Tikuna linking to /docs/about/team"

--- a/docs/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/es/docusaurus-theme-classic/navbar.json
@@ -7,6 +7,10 @@
     "message": "Acerca Tikuna",
     "description": "Navbar item with label About Tikuna"
   },
+  "item.label.Monitoring": {
+    "message": "Monitoreo",
+    "description": "Navbar item with label Monitoring"
+  },
   "item.label.Blog": {
     "message": "Blog",
     "description": "Navbar item with label Blog"

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -10,6 +10,11 @@ const sidebars = {
       label: "About",
       items: ["about/team", "about/sakundi", "about/edenia"],
     },
+    {
+      type: "category",
+      label: "Monitoring",
+      items: ["monitoring/beacon-node"],
+    },
   ],
 };
 


### PR DESCRIPTION
### Title
Add dashboard monitoring beacon node
### What does this PR do?
Add a new group monitoring, and add the public grafana dashboard to show de default metrics for beacon node

### Steps to test

    1. Run yarn build
    2. Run yarn start
    3 .Go to localhost:3000
    4. Go to test the page


#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
