### PR TITLE
Change grafana dashboard from iframe for link

### DIFF
--- a/docs/docs/monitoring/beacon-node.md
+++ b/docs/docs/monitoring/beacon-node.md
@@ -7,4 +7,6 @@ keywords: [tikuna, team, scientists]
 custom_edit_url: null
 ---
 
-<iframe width="130%" height="500" src="https://dash.tikuna.io/public-dashboards/d7322b0297754a82bdff153e74c5d2c0?orgId=0" frameBorder="0" allowFullScreen loading="lazy"></iframe> 
+Here you can find a dashboard for available metrics for the Consensus node:
+
+[Grafana Dashboard](https://dash.tikuna.io/public-dashboards/d7322b0297754a82bdff153e74c5d2c0?orgId=0)

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/monitoring/beacon-node.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/monitoring/beacon-node.md
@@ -7,4 +7,6 @@ keywords: [tikuna, team, scientists]
 custom_edit_url: null
 ---
 
-<iframe width="130%" height="500" src="https://dash.tikuna.io/public-dashboards/d7322b0297754a82bdff153e74c5d2c0?orgId=0" frameBorder="0" allowFullScreen loading="lazy"></iframe> 
+Aquí puede encontrar un tablero para las métricas disponibles para el nodo Consenso:
+
+[Tablero de Grafana](https://dash.tikuna.io/public-dashboards/d7322b0297754a82bdff153e74c5d2c0?orgId=0)


### PR DESCRIPTION
### Title
Change grafana dashboard from iframe for link
### What does this PR do?
Change grafana dashboard from iframe for link
- resolves #issueNumber

### Steps to test
1. Run yarn build
2. Run yarn start
3 .Go to localhost:3000
4. Go to test the page

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
